### PR TITLE
マウスの入力のほかにタッチによる入力も検出対象とする

### DIFF
--- a/Scripts/UniWinApi.cs
+++ b/Scripts/UniWinApi.cs
@@ -453,7 +453,8 @@ namespace Kirurobo
             List<WindowHandle> windowList = new List<WindowHandle>();
             foreach (IntPtr hwnd in hWndList)
             {
-                if (WinApi.IsWindow(hwnd)) {
+                if (WinApi.IsWindow(hwnd))
+                {
                     WindowHandle window = new WindowHandle(hwnd);
                     windowList.Add(window);
                 }
@@ -659,7 +660,7 @@ namespace Kirurobo
             return file;
         }
 
-#region マウス操作関連
+        #region マウス操作関連
         /// <summary>
         /// マウスカーソルを指定座標へ移動させる
         /// </summary>
@@ -723,9 +724,9 @@ namespace Kirurobo
                 0, 0, 0, IntPtr.Zero
                 );
         }
-#endregion
+        #endregion
 
-#region キー操作関連
+        #region キー操作関連
         /// <summary>
         /// キーコードを送ります
         /// </summary>
@@ -733,9 +734,9 @@ namespace Kirurobo
         {
             WinApi.PostMessage(this.hWnd, WinApi.WM_IME_CHAR, (long)code, IntPtr.Zero);
         }
-#endregion
+        #endregion
 
-#region ファイルドロップ関連
+        #region ファイルドロップ関連
         /// <summary>
         /// ファイルドロップ時に発生するイベント
         /// </summary>
@@ -920,9 +921,9 @@ namespace Kirurobo
             RestoreWindowState();
         }
 
-#endregion
+        #endregion
 
-#region File open dialog
+        #region File open dialog
 
         public string ShowOpenFileDialog(string filter = "All files|*.*")
         {
@@ -950,7 +951,7 @@ namespace Kirurobo
             }
             return null;
         }
-#endregion
+        #endregion
     }
 
 }

--- a/Scripts/WindowController.cs
+++ b/Scripts/WindowController.cs
@@ -139,6 +139,11 @@ namespace Kirurobo
         private Vector2 lastMousePosition;
 
         /// <summary>
+        /// 最後のドラッグはマウスによるものか、タッチによるものか
+        /// </summary>
+        private bool wasUsingMouse;
+
+        /// <summary>
         /// 現在対象としているウィンドウが自分自身らしいと確認できたらtrueとする
         /// </summary>
         private bool isWindowChecked = false;
@@ -291,14 +296,37 @@ namespace Kirurobo
             {
                 lastMousePosition = UniWinApi.GetCursorPosition();
                 isDragging = true;
+                wasUsingMouse = true;
             }
-            if (!Input.GetMouseButton(0))
+            bool touching = false;
+            if (Input.touchCount > 0)
+            {
+                Touch touch = Input.GetTouch(0);
+                lastMousePosition = touch.rawPosition;
+                isDragging = true;
+                wasUsingMouse = false;
+                touching = true;
+            }
+            if (wasUsingMouse && !Input.GetMouseButton(0))
+            {
+                isDragging = false;
+            }
+            else if (!wasUsingMouse && !touching)
             {
                 isDragging = false;
             }
             if (isDragging)
             {
-                Vector2 mousePos = UniWinApi.GetCursorPosition();
+                Vector2 mousePos;
+                if (wasUsingMouse)
+                {
+                    mousePos = UniWinApi.GetCursorPosition();
+                }
+                else
+                {
+                    Touch touch = Input.GetTouch(0);
+                    mousePos = touch.rawPosition;
+                }
                 Vector2 delta = mousePos - lastMousePosition;
                 lastMousePosition = mousePos;
 
@@ -354,7 +382,15 @@ namespace Kirurobo
             // カメラが不明ならば何もしない
             if (!cam) return;
 
-            Vector2 mousePos = Input.mousePosition;
+            Vector2 mousePos;
+            if (Input.touchCount > 0)
+            {
+                mousePos = Input.touches[0].position;
+            }
+            else
+            {
+                mousePos = Input.mousePosition;
+            }
             Rect camRect = cam.pixelRect;
 
             //// コルーチン & WaitForEndOfFrame ではなく、OnPostRenderで呼ぶならば、MSAAによって上下反転しないといけない？

--- a/Scripts/WindowController.cs
+++ b/Scripts/WindowController.cs
@@ -225,7 +225,8 @@ namespace Kirurobo
 
         void OnDestroy()
         {
-            if (uniWin != null) {
+            if (uniWin != null)
+            {
                 uniWin.Dispose();
             }
         }
@@ -247,7 +248,8 @@ namespace Kirurobo
             DragMove();
 
             // ウィンドウ枠が復活している場合があるので監視するため、呼ぶ
-            if (uniWin != null) {
+            if (uniWin != null)
+            {
                 uniWin.Update();
             }
         }
@@ -643,7 +645,8 @@ namespace Kirurobo
         {
             if (Application.isPlaying)
             {
-                if (uniWin != null) {
+                if (uniWin != null)
+                {
                     uniWin.Dispose();
                 }
             }


### PR DESCRIPTION
暫定でタッチ入力も対応、ただ完全ではない

マウスの場合、クリックの有無をとわずカーソルが常に画面内に存在しているため、クリックされていない状態であってもカーソルの位置からモデルとの衝突判定が「事前に」可能である。マウスとモデルが衝突しているおり、かつUnityウィンドウが最前面に存在していない場合に、Unityウィンドウを最前面に移動する処理を済ませておく。これによって、マウスがクリックできる状態に至るまでにウィンドウは最前面にいるので、マウスイベントを漏らさず安心して処理できる。

一方、タッチ操作の場合は非タッチ時＝カーソルがどこにもない。タッチされて初めてモデルとの衝突判定が行われるので、Unityウィンドウが最前面に移動する処理を挟む機会がない。

…という課題が残っておりますがPR出します。