### PR TITLE
Develop

### DIFF
--- a/Scripts/UniWinApi.cs
+++ b/Scripts/UniWinApi.cs
@@ -102,6 +102,16 @@ namespace Kirurobo
             }
         }
 
+        /// <summary>
+        /// 透明化の方式
+        /// </summary>
+        public enum TransparentType
+        {
+            None = 0,
+            DWM = 1,
+            LayereredWindows = 2,
+        }
+
 
         /// <summary>
         /// このウィンドウのハンドル
@@ -141,6 +151,17 @@ namespace Kirurobo
         /// 標準ウィンドウサイズの指定
         /// </summary>
         public Vector2 OriginalWindowSize;
+
+        /// <summary>
+        /// ウィンドウ透過方式
+        /// </summary>
+        public TransparentType TransparentMode = TransparentType.DWM;
+        private TransparentType currentTransparentType = TransparentType.DWM;
+
+        /// <summary>
+        /// Layered Windows で透過する色
+        /// </summary>
+        public Color32 ChromakeyColor = new Color32(1, 0, 1, 0);
 
         /// <summary>
         /// 元のウィンドウスタイル
@@ -518,25 +539,40 @@ namespace Kirurobo
                 // 枠無しウィンドウにする
                 EnableBorderless(true);
 
-                EnableTransparentByDWM();
-
-                // ウィンドウ再描画
-                WinApi.ShowWindow(hWnd, WinApi.SW_SHOW);
-                SetSize(GetSize());
+                switch (TransparentMode)
+                {
+                    case TransparentType.DWM:
+                        EnableTransparentByDWM();
+                        break;
+                    case TransparentType.LayereredWindows:
+                        EnableTransparentBySetLayered();
+                        break;
+                }
             }
             else
             {
-                DisableTransparentByDWM();
+                // 現在の指定ではなく、透過にした時点の指定に基づいて無効化
+                switch (currentTransparentType)
+                {
+                    case TransparentType.DWM:
+                        DisableTransparentByDWM();
+                        break;
+                    case TransparentType.LayereredWindows:
+                        DisableTransparentBySetLayered();
+                        break;
+                }
 
-                // ウィンドウスタイルを戻す
+                // 枠ありウィンドウにする
                 EnableBorderless(false);
 
                 // 操作の透過をやめる
                 EnableClickThrough(false);
-
-                // サイズ変更イベントを発生させる
-                SetSize(GetSize());
             }
+
+            currentTransparentType = TransparentMode;
+
+            // サイズ変更イベントを発生させる
+            SetSize(GetSize());
 
             // ウィンドウ再描画
             WinApi.ShowWindow(hWnd, WinApi.SW_SHOW);
@@ -554,6 +590,43 @@ namespace Kirurobo
             //	※ 本来のウィンドウが何らかの範囲指定でGlassにしていた場合は、残念ながら表示が戻りません
             DwmApi.MARGINS margins = new DwmApi.MARGINS(0, 0, 0, 0);
             DwmApi.DwmExtendFrameIntoClientArea(hWnd, margins);
+        }
+
+        /// <summary>
+        /// SetLayeredWindowsAttributes によって指定色を透過させる
+        /// </summary>
+        private void EnableTransparentBySetLayered()
+        {
+#if UNITY_EDITOR
+            // エディタの場合、設定すると描画が更新されなくなってしまう
+#else
+            Color32 color32 = ChromakeyColor;
+            WinApi.COLORREF cref = new WinApi.COLORREF(color32.r, color32.g, color32.b);
+            WinApi.SetLayeredWindowAttributes(hWnd, cref, 0xFF, WinApi.LWA_COLORKEY);
+
+            long exstyle = this.CurrentWindowExStyle;
+            exstyle |= WinApi.WS_EX_LAYERED;
+            this.CurrentWindowExStyle = exstyle;
+            WinApi.SetWindowLong(hWnd, WinApi.GWL_EXSTYLE, this.CurrentWindowExStyle);
+#endif
+        }
+
+        /// <summary>
+        /// SetLayeredWindowsAttributes によって指定色を透過させる
+        /// </summary>
+        private void DisableTransparentBySetLayered()
+        {
+#if UNITY_EDITOR
+            // エディタの場合、設定すると描画が更新されなくなってしまう
+#else
+            WinApi.COLORREF cref = new WinApi.COLORREF(0, 0, 0);
+            WinApi.SetLayeredWindowAttributes(hWnd, cref, 0xFF, 0x00);
+
+            long exstyle = this.CurrentWindowExStyle;
+            exstyle &= ~WinApi.WS_EX_LAYERED;
+            this.CurrentWindowExStyle = exstyle;
+            WinApi.SetWindowLong(hWnd, WinApi.GWL_EXSTYLE, this.CurrentWindowExStyle);
+#endif
         }
 
         /// <summary>
@@ -591,6 +664,9 @@ namespace Kirurobo
         public void EnableClickThrough(bool isClickThrough)
         {
             if (!IsActive) return;
+
+            // Layered Window での透過時は、操作透過はOSで行われる
+            if (currentTransparentType == TransparentType.LayereredWindows) return;
 
 #if UNITY_EDITOR
             // エディタの場合は操作の透過はやめておく
@@ -674,7 +750,7 @@ namespace Kirurobo
             return file;
         }
 
-        #region マウス操作関連
+#region マウス操作関連
         /// <summary>
         /// マウスカーソルを指定座標へ移動させる
         /// </summary>
@@ -753,9 +829,9 @@ namespace Kirurobo
                 0, 0, 0, IntPtr.Zero
                 );
         }
-        #endregion
+#endregion
 
-        #region キー操作関連
+#region キー操作関連
         /// <summary>
         /// キーコードを送ります
         /// </summary>
@@ -763,9 +839,9 @@ namespace Kirurobo
         {
             WinApi.PostMessage(this.hWnd, WinApi.WM_IME_CHAR, (long)code, IntPtr.Zero);
         }
-        #endregion
+#endregion
 
-        #region ファイルドロップ関連
+#region ファイルドロップ関連
         /// <summary>
         /// ファイルドロップ時に発生するイベント
         /// </summary>
@@ -950,9 +1026,9 @@ namespace Kirurobo
             RestoreWindowState();
         }
 
-        #endregion
+#endregion
 
-        #region File open dialog
+#region File open dialog
 
         public string ShowOpenFileDialog(string filter = "All files|*.*")
         {
@@ -980,7 +1056,7 @@ namespace Kirurobo
             }
             return null;
         }
-        #endregion
+#endregion
     }
 
 }

--- a/Scripts/UniWinApi.cs
+++ b/Scripts/UniWinApi.cs
@@ -155,7 +155,7 @@ namespace Kirurobo
         /// <summary>
         /// ウィンドウ透過方式
         /// </summary>
-        public TransparentType TransparentMode = TransparentType.DWM;
+        public TransparentType TransparentMethod = TransparentType.DWM;
         private TransparentType currentTransparentType = TransparentType.DWM;
 
         /// <summary>
@@ -539,7 +539,7 @@ namespace Kirurobo
                 // 枠無しウィンドウにする
                 EnableBorderless(true);
 
-                switch (TransparentMode)
+                switch (TransparentMethod)
                 {
                     case TransparentType.DWM:
                         EnableTransparentByDWM();
@@ -569,7 +569,7 @@ namespace Kirurobo
                 EnableClickThrough(false);
             }
 
-            currentTransparentType = TransparentMode;
+            currentTransparentType = TransparentMethod;
 
             // サイズ変更イベントを発生させる
             SetSize(GetSize());

--- a/Scripts/WindowController.cs
+++ b/Scripts/WindowController.cs
@@ -116,7 +116,7 @@ namespace Kirurobo
         /// <summary>
         /// 透過方式の指定
         /// </summary>
-        public UniWinApi.TransparentType transparentType = UniWinApi.TransparentType.DWM;
+        public UniWinApi.TransparentType transparentMethod = UniWinApi.TransparentType.DWM;
 
         // カメラの背景をアルファゼロの黒に置き換えるため、本来の背景を保存しておく変数
         private CameraClearFlags originalCameraClearFlags;
@@ -232,7 +232,7 @@ namespace Kirurobo
             uniWin = new UniWinApi();
 
             // 透過方式の指定
-            uniWin.TransparentMode = transparentType;
+            uniWin.TransparentMethod = transparentMethod;
 
             // 自分のウィンドウを取得
             FindMyWindow();
@@ -276,27 +276,6 @@ namespace Kirurobo
             // キー、マウス操作の下ウィンドウへの透過状態を更新
             UpdateClickThrough();
 
-
-            // デバッグ用
-            if (uniWin != null)
-            {
-                // [Ctrl]+[T] で透過方式を変更
-                if (Input.GetKeyDown(KeyCode.T) && Input.GetKey(KeyCode.LeftControl))
-                {
-                    //Debug.Log(Screen.width + " : " + Screen.height);
-                    //uniWin.SetPosition(Vector2.zero);
-
-                    // 透過モード入れ替え
-                    if (uniWin.TransparentMode == UniWinApi.TransparentType.LayereredWindows)
-                    {
-                        uniWin.TransparentMode = UniWinApi.TransparentType.DWM;
-                    } else
-                    {
-                        uniWin.TransparentMode = UniWinApi.TransparentType.LayereredWindows;
-                    }
-                    transparentType = uniWin.TransparentMode;
-                }
-            }
 
             // ウィンドウ枠が復活している場合があるので監視するため、呼ぶ
             if (uniWin != null)
@@ -646,7 +625,7 @@ namespace Kirurobo
             if (isTransparent)
             {
                 currentCamera.clearFlags = CameraClearFlags.SolidColor;
-                if (uniWin.TransparentMode == UniWinApi.TransparentType.LayereredWindows)
+                if (uniWin.TransparentMethod == UniWinApi.TransparentType.LayereredWindows)
                 {
                     currentCamera.backgroundColor = uniWin.ChromakeyColor;
                 }
@@ -679,6 +658,26 @@ namespace Kirurobo
             }
             UpdateClickThrough();
             StateChangedEvent();
+        }
+
+        /// <summary>
+        /// 透明化方式を設定
+        /// </summary>
+        /// <param name="method"></param>
+        public void SetTransparentMethod(UniWinApi.TransparentType method)
+        {
+            //Debug.Log(Screen.width + " : " + Screen.height);
+            //uniWin.SetPosition(Vector2.zero);
+
+            // 透過モード変更
+            uniWin.TransparentMethod = method;
+            transparentMethod = uniWin.TransparentMethod;
+            if (isTransparent)
+            {
+                // 透明化状態だったならば再度透明化を設定し直す
+                uniWin.EnableTransparent(false);
+                uniWin.EnableTransparent(true);
+            }
         }
 
         /// <summary>

--- a/Scripts/WindowController.cs
+++ b/Scripts/WindowController.cs
@@ -331,7 +331,7 @@ namespace Kirurobo
                 dragStartedPosition = Input.mousePosition;
                 isDragging = true;
                 wasUsingMouse = true;
-                Debug.Log("Start mouse dragging");
+                //Debug.Log("Start mouse dragging");
             }
 
             bool touching = (activeFingerId >= 0);
@@ -344,7 +344,7 @@ namespace Kirurobo
                 {
                     if (Input.GetTouch(i).phase == TouchPhase.Began)
                     {
-                        Debug.Log("Touch began");
+                        //Debug.Log("Touch began");
                         //targetTouchIndex = i;
                         firstTouch = Input.GetTouch(i);     // まだドラッグ開始とはせず、透過画素判定に回す。
                         break;
@@ -520,6 +520,9 @@ namespace Kirurobo
             // 透過状態でなければ、範囲内なら不透過扱いとする
             if (!_isTransparent) return true;
 
+            // LayeredWindowならばクリックスルーはOSに任せるため、ウィンドウ内ならtrueを返しておく
+            if (transparentMethod == UniWinApi.TransparentType.LayereredWindows) return true;
+
             // 指定座標の描画結果を見て判断
             try   // WaitForEndOfFrame のタイミングで実行すればtryは無くても大丈夫？
             {
@@ -675,8 +678,8 @@ namespace Kirurobo
             if (isTransparent)
             {
                 // 透明化状態だったならば再度透明化を設定し直す
-                uniWin.EnableTransparent(false);
-                uniWin.EnableTransparent(true);
+                SetTransparent(false);
+                SetTransparent(true);
             }
         }
 


### PR DESCRIPTION
- Unity 2019 で透過を使うための自動設定を追加。
- 透明化方式を DWM(Aero) と LayeredWindow から選択できるようにした。
  - LayeredWindowを選ぶと単色をマスクとして抜く形となる。
    - 半透明ができないが、クリックスルーをOSに任せられる分、負荷が下がり、タッチ操作にも自然な対応とできる。
  - 両者の名称がそれで良いのかは不安。

